### PR TITLE
Throw specific error if no response body or header is present

### DIFF
--- a/src/validate-json-schema-middleware.js
+++ b/src/validate-json-schema-middleware.js
@@ -4,7 +4,7 @@ import get from 'lodash/get'
 
 const getBodyValidator = swaggerEndPoint => swaggerEndPoint.body
 const getParametersValidator = swaggerEndPoint => swaggerEndPoint.parameters
-const getResponseEndPoint = swaggerEndPoint => swaggerEndPoint.responses
+const getResponseValidator = swaggerEndPoint => swaggerEndPoint.responses
 
 const getSwaggerEndPoint = (schema, path) => {
   const swaggerEndPoint = get(schema, path)
@@ -64,10 +64,13 @@ const OpenApiValidator = async (swaggerPath, options) => {
 
   const getResponseValidationEndPoint = (path) => {
     const swaggerEndPoint = getSwaggerEndPoint(schema, path)
-    const responseEndPoint = getResponseEndPoint(swaggerEndPoint)
+    const responseValidators = getResponseValidator(swaggerEndPoint)
     return {
       validator: (httpStatusCode) => {
-        const validator = responseEndPoint[httpStatusCode]
+        const validator = responseValidators[httpStatusCode]
+        if (validator == null) {
+          throw new Error(`validator not found at path '${path.join(',')}'. Have you defined a response body or header?`)
+        }
         ensureValidator(validator, schema, path, httpStatusCode)
         return validator
       },


### PR DESCRIPTION
This PR makes the error message more user friendly in case he tries to
validate a response without body or header.
Additionally, it renames the variable to reflect that we are getting a
validator as in the other cases.

See https://github.com/Zooz/api-schema-builder/tree/5d6ff44ecc298b7cbd4804b6f19eba5950a42793#response